### PR TITLE
Merge 25-secrets-dotenv-migrate into develop

### DIFF
--- a/.env.vault
+++ b/.env.vault
@@ -1,0 +1,25 @@
+#/-------------------.env.vault---------------------/
+#/         cloud-agnostic vaulting standard         /
+#/   [how it works](https://dotenv.org/env-vault)   /
+#/--------------------------------------------------/
+
+# development
+DOTENV_VAULT_DEVELOPMENT="u2a8y+rNVm6nL/L5vReDtzTWcx9rNhqHR9/kYI7frNV/3m/xyA8HvxoRl+K9JIUjU76ycBSPGNzeizOfdBGLvKnHOjDfd7mqInhmeTIm4xUE71ZA2D0KC0Rnr5VYSgoZp4gbzaRAnf7sA+Kny8bkgAtBcuaDTJUpFUo6FkiFmsa974TAhF0Q0q9oHVqZi7ktk6FcscQe5TNnSUnUxXsAF79aUvrG3HUGjaT8eWe80fL81U1s2pd0QRxeY3D+MrMjDP0ZCjxeg7C19WcyF6JT6XWXJOrhdogTPJwEOSPobEDm4Os4GOPRCGPNz29UUtNg/R4kN3uQThYqIatb6Df3KKsWY/4D++9AWfqP3HJUkRyWl7z5mIUR0yH8kA/SXkQH1pR1GjTBr0MfYxEWi6HeRuGg6nzjJrtVM2QgsActyR0S7ZaocZE4q+SejV/e7WcuyoTqa2LyOQ3mmmLLk7Baoejc1evtbkpGi/jC84tzqACJiZqQIY8fUIMynPZTY0m21kVM97iDQHaqaBmhxLBYezw="
+DOTENV_VAULT_DEVELOPMENT_VERSION=1
+
+# ci
+DOTENV_VAULT_CI="OE9nFgSLDDwUkw0ZiEMtgWc7Q71Sut0RkUy5sR4iywQrjKL2"
+DOTENV_VAULT_CI_VERSION=1
+
+# staging
+DOTENV_VAULT_STAGING="s4/EYP6noF1qduKK4hwBrTKOC0ZUyvPPFUyw+aremdCMlS2C"
+DOTENV_VAULT_STAGING_VERSION=1
+
+# production
+DOTENV_VAULT_PRODUCTION="bPMDNCdlQ+mrNkfbXzmjpxsLFf4opZU7m3MdLyrvuFSP79sN"
+DOTENV_VAULT_PRODUCTION_VERSION=1
+
+#/----------------settings/metadata-----------------/
+DOTENV_VAULT="vlt_bbdd92e351c43dcfac195bf872e8a6c495ca7cf6bb588eea5d73a0c61d8fb7fc"
+DOTENV_API_URL="https://vault.dotenv.org"
+DOTENV_CLI="npx dotenv-vault@latest"

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,8 @@ public/workbox-*
 
 # Sentry Auth Token
 .sentryclirc
+
+.env*
+.flaskenv*
+!.env.project
+!.env.vault

--- a/.infisical.json
+++ b/.infisical.json
@@ -1,5 +1,0 @@
-{
-    "workspaceId": "655e709a5015e3db3da7c8c6",
-    "defaultEnvironment": "",
-    "gitBranchToEnvironmentMapping": null
-}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build-dev": "infisical run -- npm run dev",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
## What

Migrated the project away from using Infisical to Dotenv as it's secret manager.

## Why

Infisical has some limitations around number of projects per organisation, which could lead to issues further down the line if we start branching out into other repos.

## How

1. Removed the `infisical.json` and the `build-dev` infisical specific node script.
1. Added .env.vault file to the project.

## Checklist

- [x] I have tested these changes locally
- [x] I have ensured my code follows the project's coding style
- [ ] I have updated the documentation accordingly
- [x] My changes do not introduce any new warnings or errors
- [ ] All tests pass successfully
- [ ] I have added/updated unit tests (if necessary)