### PR TITLE
Merge 24-metadata-component into develop

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -6,6 +6,10 @@ import type { Metadata, Viewport } from 'next'
 import Head from 'next/head'
 import Link from 'next/link'
 import { ThemeProvider } from '@/components/theme-provider'
+import icons from '@/lib/metadata/icons'
+import openGraph from '@/lib/metadata/openGraph'
+import robots from '@/lib/metadata/robot'
+import twitter from '@/lib/metadata/twitter'
 
 export const viewport: Viewport = {
 	themeColor: '#3A86FF'
@@ -17,40 +21,7 @@ export const metadata: Metadata = {
     'Making education more accessible, collaborative, and engaging.',
 	applicationName: 'StudyCrew',
 	manifest: '/manifest.json',
-	icons: [
-		{
-			url: '/assets/maskable_icon_x48',
-			type: 'image/png',
-			sizes: '48x48'
-		},
-		{
-			url: '/assets/maskable_icon_x72',
-			type: 'image/png',
-			sizes: '72x72'
-		},
-		{
-			url: '/assets/maskable_icon_x96.png',
-			type: 'image/png',
-			sizes: '96x96'
-		},
-		{
-			url: '/assets/maskable_icon_x128.png',
-			type: 'image/png',
-			sizes: '128x128'
-		},
-		{
-			url: '/assets/maskable_icon_x192.png',
-			type: 'image/png',
-			sizes: '192x192',
-			rel: 'apple-touch-icon'
-		},
-		{
-			url: '/assets/maskable_icon_x384.png',
-			type: 'image/png',
-			sizes: '384x384',
-			rel: 'apple-touch-icon'
-		}
-	],
+	icons,
 	appleWebApp: {
 		capable: true,
 		statusBarStyle: 'default',
@@ -59,23 +30,9 @@ export const metadata: Metadata = {
 	formatDetection: {
 		telephone: false
 	},
-	openGraph: {
-		type: 'website',
-		siteName: 'StudyCrew',
-		title: {
-			default: 'StudyCrew',
-			template: '% - PWA App'
-		},
-		description: 'Making education more accessible, collaborative, and engaging.'
-	},
-	twitter: {
-		card: 'summary',
-		title: {
-			default: 'StudyCrew',
-			template: '% - PWA App'
-		},
-		description: 'Making education more accessible, collaborative, and engaging.'
-	}
+	openGraph,
+	robots,
+	twitter
 }
 
 export default function RootLayout ({

--- a/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -1,5 +1,12 @@
 import React from 'react'
 import { SignIn } from '@clerk/nextjs'
+import { type Metadata } from 'next'
+
+export const metadata: Metadata = {
+	title: 'Sign In | StudyCrew',
+	description:
+	'Sign in to continue your journey to a better education.'
+}
 
 export default function Page (): JSX.Element {
 	return <SignIn />

--- a/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -1,5 +1,12 @@
 import React from 'react'
 import { SignUp } from '@clerk/nextjs'
+import { type Metadata } from 'next'
+
+export const metadata: Metadata = {
+	title: 'Sign Up | StudyCrew',
+	description:
+	'Sign up now to start your journey to a better education.'
+}
 
 export default function Page (): JSX.Element {
 	return <SignUp />

--- a/app/(root)/layout.tsx
+++ b/app/(root)/layout.tsx
@@ -7,6 +7,10 @@ import Head from 'next/head'
 import Link from 'next/link'
 import '../globals.css'
 import '../../styles/landing.css'
+import icons from '@/lib/metadata/icons'
+import openGraph from '@/lib/metadata/openGraph'
+import robots from '@/lib/metadata/robot'
+import twitter from '@/lib/metadata/twitter'
 
 export const viewport: Viewport = {
 	themeColor: '#3A86FF'
@@ -18,40 +22,7 @@ export const metadata: Metadata = {
     'Making education more accessible, collaborative, and engaging.',
 	applicationName: 'StudyCrew',
 	manifest: '/manifest.json',
-	icons: [
-		{
-			url: '/assets/maskable_icon_x48',
-			type: 'image/png',
-			sizes: '48x48'
-		},
-		{
-			url: '/assets/maskable_icon_x72',
-			type: 'image/png',
-			sizes: '72x72'
-		},
-		{
-			url: '/assets/maskable_icon_x96.png',
-			type: 'image/png',
-			sizes: '96x96'
-		},
-		{
-			url: '/assets/maskable_icon_x128.png',
-			type: 'image/png',
-			sizes: '128x128'
-		},
-		{
-			url: '/assets/maskable_icon_x192.png',
-			type: 'image/png',
-			sizes: '192x192',
-			rel: 'apple-touch-icon'
-		},
-		{
-			url: '/assets/maskable_icon_x384.png',
-			type: 'image/png',
-			sizes: '384x384',
-			rel: 'apple-touch-icon'
-		}
-	],
+	icons,
 	appleWebApp: {
 		capable: true,
 		statusBarStyle: 'default',
@@ -60,23 +31,9 @@ export const metadata: Metadata = {
 	formatDetection: {
 		telephone: false
 	},
-	openGraph: {
-		type: 'website',
-		siteName: 'StudyCrew',
-		title: {
-			default: 'StudyCrew',
-			template: '% - PWA App'
-		},
-		description: 'Making education more accessible, collaborative, and engaging.'
-	},
-	twitter: {
-		card: 'summary',
-		title: {
-			default: 'StudyCrew',
-			template: '% - PWA App'
-		},
-		description: 'Making education more accessible, collaborative, and engaging.'
-	}
+	openGraph,
+	robots,
+	twitter
 }
 
 export default async function RootLayout ({

--- a/lib/metadata/icons.ts
+++ b/lib/metadata/icons.ts
@@ -1,0 +1,38 @@
+import { type Icon } from 'next/dist/lib/metadata/types/metadata-types'
+
+const icons: Icon[] = [
+	{
+		url: '/assets/maskable_icon_x48',
+		type: 'image/png',
+		sizes: '48x48'
+	},
+	{
+		url: '/assets/maskable_icon_x72',
+		type: 'image/png',
+		sizes: '72x72'
+	},
+	{
+		url: '/assets/maskable_icon_x96.png',
+		type: 'image/png',
+		sizes: '96x96'
+	},
+	{
+		url: '/assets/maskable_icon_x128.png',
+		type: 'image/png',
+		sizes: '128x128'
+	},
+	{
+		url: '/assets/maskable_icon_x192.png',
+		type: 'image/png',
+		sizes: '192x192',
+		rel: 'apple-touch-icon'
+	},
+	{
+		url: '/assets/maskable_icon_x384.png',
+		type: 'image/png',
+		sizes: '384x384',
+		rel: 'apple-touch-icon'
+	}
+]
+
+export default icons

--- a/lib/metadata/openGraph.ts
+++ b/lib/metadata/openGraph.ts
@@ -1,0 +1,51 @@
+import { type OpenGraph } from 'next/dist/lib/metadata/types/opengraph-types'
+
+const openGraph: OpenGraph = {
+	type: 'website',
+	siteName: 'StudyCrew',
+	title: {
+		default: 'StudyCrew',
+		template: '% - PWA App'
+	},
+	description: 'Making education more accessible, collaborative, and engaging.',
+	images: [
+		{
+			url: '/assets/maskable_icon_x48',
+			type: 'image/png',
+			width: '48',
+			height: '48'
+		},
+		{
+			url: '/assets/maskable_icon_x72',
+			type: 'image/png',
+			width: '72',
+			height: '72'
+		},
+		{
+			url: '/assets/maskable_icon_x96.png',
+			type: 'image/png',
+			width: '96',
+			height: '96'
+		},
+		{
+			url: '/assets/maskable_icon_x128.png',
+			type: 'image/png',
+			width: '128',
+			height: '128'
+		},
+		{
+			url: '/assets/maskable_icon_x192.png',
+			type: 'image/png',
+			width: '192',
+			height: '192'
+		},
+		{
+			url: '/assets/maskable_icon_x384.png',
+			type: 'image/png',
+			width: '384',
+			height: '384'
+		}
+	]
+}
+
+export default openGraph

--- a/lib/metadata/robot.ts
+++ b/lib/metadata/robot.ts
@@ -1,0 +1,17 @@
+import { type Robots } from 'next/dist/lib/metadata/types/metadata-types'
+
+const robots: Robots = {
+	index: true,
+	follow: true,
+	nocache: false,
+	googleBot: {
+		index: true,
+		follow: true,
+		noimageindex: true,
+		'max-image-preview': 'large',
+		'max-video-preview': 'large',
+		'max-snippet': -1
+	}
+}
+
+export default robots

--- a/lib/metadata/twitter.ts
+++ b/lib/metadata/twitter.ts
@@ -1,0 +1,13 @@
+import { type Twitter } from 'next/dist/lib/metadata/types/twitter-types'
+
+const twitter: Twitter = {
+	card: 'summary',
+	title: {
+		default: 'StudyCrew',
+		template: '% - PWA App'
+	},
+	description:
+      'Making education more accessible, collaborative, and engaging.'
+}
+
+export default twitter


### PR DESCRIPTION
## What

The metadata for the layout files was large and had lots of repeated data in it. This request was to move the metadata to a component.
Whilst not moved to a component. it has been split into smaller reusable files, so I believe this still fits the required changes, even if achieved slightly differently. 

## Why

The metadata tags on the layout pages (auth and root) had a lot of repeated code, which not only made maintainability hard, also bloated the files and made it less readable.

## How

There are a handful of new files in the `lib` folder that are now referenced in the `layout.tsx` Metadata api usage now.

## Checklist

- [x] I have tested these changes locally
- [x] I have ensured my code follows the project's coding style
- [ ] I have updated the documentation accordingly
- [x] My changes do not introduce any new warnings or errors
- [ ] All tests pass successfully
- [ ] I have added/updated unit tests (if necessary)