### PR TITLE
Merge 89-learn-more-button into develop

### DIFF
--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -1,9 +1,7 @@
 'use client'
 
-// React specific imports
 import React, { useEffect, useState } from 'react'
 import { BrowserRouter as Router } from 'react-router-dom'
-
 import Header from './../../components/Header/Header'
 import Hero from './../../components/Hero/Hero'
 import Mission from './../../components/Mission/Mission'
@@ -13,17 +11,17 @@ import SignUp from './../../components/SignUp/Signup'
 import Team from './../../components/Team/Team'
 import Footer from './../../components/Footer/Footer'
 import Faqs from './../../components/FAQs/Faqs'
-
 import useScrollFadeIn from './../../lib/hooks/useFadeIn'
-const FadingHero = useScrollFadeIn(Hero)
-const FadingMission = useScrollFadeIn(Mission)
-const FadingFeatures = useScrollFadeIn(Features)
-const FadingProject = useScrollFadeIn(Project)
-const FadingSignUp = useScrollFadeIn(SignUp)
-const FadingTeam = useScrollFadeIn(Team)
-const FadingFAQ = useScrollFadeIn(Faqs)
+import scrollToRef from '@/lib/hooks/scrollTo'
+
 
 function App (): JSX.Element {
+	const handleLearnMoreClick = (): void => {
+		setActivePage('features')
+		scrollToRef(featuresRef)
+	}
+	const animatedItem = useScrollFadeIn();
+
 	// State for the active page section
 	const [activePage, setActivePage] = useState('')
 
@@ -122,30 +120,33 @@ function App (): JSX.Element {
 			</div>
 
 			{/* Various site sections */}
-			<FadingHero id="hero" delay={100} />
+			<Hero
+				handleLearnMoreClick={handleLearnMoreClick}
+				{...animatedItem}
+			/>
 
 			<div className="mission-component" ref={missionRef}>
-				<FadingMission id="mission" />
+				<Mission {...animatedItem} />
 			</div>
 
 			<div className="features-component" ref={featuresRef}>
-				<FadingFeatures id="features" />
+				<Features {...animatedItem} />
 			</div>
 
 			<div className="project-component" ref={projectRef}>
-				<FadingProject id="project" />
+				<Project {...animatedItem} />
 			</div>
 
 			<div className="empower-component" ref={signupRef}>
-				<FadingSignUp id="sign-up" />
+				<SignUp {...animatedItem} />
 			</div>
 
 			<div className="team-component" ref={teamRef}>
-				<FadingTeam id="team" />
+				<Team {...animatedItem} />
 			</div>
 
 			<div className="faq-component" ref={faqRef}>
-				<FadingFAQ id="faq" />
+				<Faqs {...animatedItem} />
 			</div>
 
 			{/* Footer */}
@@ -164,4 +165,5 @@ function App (): JSX.Element {
 		</Router>
 	)
 }
+
 export default App

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { FaFacebookF, FaLinkedin, FaGithubSquare, FaTwitter, FaDiscord } from 'react-icons/fa'
 import './Footer.css'
+import scrollToRef from '@/lib/hooks/scrollTo'
 
 interface FooterProps {
 	activePage: string
@@ -25,14 +26,7 @@ const Footer = ({
 }: FooterProps): JSX.Element => {
 	// Helper function to determine if a link is active
 	const isActive = (name: string): string => activePage === name ? 'activeNavLink' : ''
-	// Scrolls smoothly to the provided reference
-	const scrollToRef = (ref: React.MutableRefObject<null>): void => {
-		const refContainerCurrent = ref.current as HTMLDivElement | null
-		if (refContainerCurrent) {
-			const y = refContainerCurrent.getBoundingClientRect().top + window.scrollY + -60
-			window.scrollTo({ top: y, behavior: 'smooth' })
-		}
-	}
+
 	// Handles the navigation link click based on the section's name
 	const handleNavLinkClick = (name: string): void => {
 		let ref

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -20,7 +20,9 @@ import { FaChevronRight, FaChevronDown } from 'react-icons/fa'
 
 const words = ['Collaborative', 'Accessible', 'Engaging']
 
-const Hero = (): JSX.Element => {
+const Hero = (props: {
+	handleLearnMoreClick: () => void,
+}): JSX.Element => {
 	// Change word in header
 	const [currentWord, setCurrentWord] = useState('Collaborative')
 	const [opacity, setOpacity] = useState(1)
@@ -70,16 +72,9 @@ const Hero = (): JSX.Element => {
 
 				{/* Group of buttons with different styles and sizes */}
 				<div className="button-group">
-					<Link to="/waitlist">
-						<Button size="big">Join Waitlist
-							<FaChevronRight className="icon-inline" />
-						</Button>
-					</Link>
-					<Link to="/waitlist">
-						<Button variant="outline" size="big-outline">Learn More
-							<FaChevronDown className="icon-inline" />
-						</Button>
-					</Link>
+					<Button onClick={props.handleLearnMoreClick} variant="outline" size="big-outline">Learn More
+						<FaChevronDown className="icon-inline" />
+					</Button>
 				</div>
 			</div>
 		</div>

--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -1,3 +1,4 @@
+import scrollToRef from '@/lib/hooks/scrollTo'
 import './Navbar.css'
 
 import React from 'react'
@@ -27,15 +28,6 @@ const Navbar = ({
 }: NavbarProps): JSX.Element => {
 	// Helper function to determine if a link is active
 	const isActive = (name: string): string => activePage === name ? 'activeNavLink' : ''
-
-	// Scrolls smoothly to the provided reference
-	const scrollToRef = (ref: React.MutableRefObject<null>): void => {
-		const refContainerCurrent = ref.current as HTMLDivElement | null
-		if (refContainerCurrent) {
-			const y = refContainerCurrent.getBoundingClientRect().top + window.scrollY + -60
-			window.scrollTo({ top: y, behavior: 'smooth' })
-		}
-	}
 
 	// Handles the navigation link click based on the section's name
 	const handleNavLinkClick = (name: string): void => {

--- a/lib/hooks/scrollTo.ts
+++ b/lib/hooks/scrollTo.ts
@@ -1,0 +1,9 @@
+const scrollToRef = (ref: React.MutableRefObject<null>): void => {
+	const refContainerCurrent = ref.current as HTMLDivElement | null
+	if (refContainerCurrent) {
+		const y = refContainerCurrent.getBoundingClientRect().top + window.scrollY + -60
+		window.scrollTo({ top: y, behavior: 'smooth' })
+	}
+}
+
+export default scrollToRef


### PR DESCRIPTION
## What

Links the Learn More hero button to a function

## Why

The Learn More hero button currently does nothing

## How

There is now an onclick which is passed from the hero to the page, which then triggers the scrollToRef function.
Some moving around and refactoring was done to make this a little cleaner.


## Related Issues

This issue now blocks #87, as the overlap between work needed in both is high. Once this has been merged, we can then very quickly get #87 done and then the hero section is completed.

## Checklist

- [x] I have tested these changes locally
- [x] I have ensured my code follows the project's coding style
- [ ] I have updated the documentation accordingly
- [x] My changes do not introduce any new warnings or errors
- [x] All tests pass successfully
- [ ] I have added/updated unit tests (if necessary)