### PR TITLE
Merge 94-readme-build-dev into develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To run the project locally, you need to:
 
 1. `pnpm i` the required dependencies.
 
-1. `pnpm build-dev` to launch the development server.
+1. `pnpm dev` to launch the development server.
 
 ## Contributing
 Interested in contributing? Check out our contribution guide to learn how you can get involved and contribute to StudyCrew's development.


### PR DESCRIPTION
## What

Updated readme doc to fix running locally command guidance

## Why

The command in the running locally section was incorrect and would lead to people not being to run the project if they just followed the readme.

## How

Updated the text.

## Screenshots / GIFs (if applicable)

![image](https://github.com/StudyCrew/StudyCrew/assets/74150974/4b83eef4-e873-4464-a18b-bb78285af794)

## Checklist

- [x] I have tested these changes locally
- [x] I have ensured my code follows the project's coding style
- [x] I have updated the documentation accordingly
- [x] My changes do not introduce any new warnings or errors
- [x] All tests pass successfully
- [ ] I have added/updated unit tests (if necessary)