### PR TITLE
Fix: README command to start dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ Sentry.init({
 To run the project locally, you need to:
 
 1. `pnpm i` the required dependencies.
-
-1. `pnpm build-dev` to launch the development server.
+2. `pnpm dev` to launch the development server.
 
 ## Contributing
 Interested in contributing? Check out our contribution guide to learn how you can get involved and contribute to StudyCrew's development.


### PR DESCRIPTION
## What

Updates the `pnpm` command to launch the dev server in the **Getting Started** section to be `pnpm dev` instead of `pnpm build-dev`. Also numbers it as the 2nd item in the list 🙂 

## Checklist

- [x] I have tested these changes locally
- [x] I have ensured my code follows the project's coding style
- [x] I have updated the documentation accordingly
- [x] My changes do not introduce any new warnings or errors
- [x] All tests pass successfully
- [x] I have added/updated unit tests (if necessary)

