### PR TITLE
Merge 78-layout-mobile-overflow into develop

### DIFF
--- a/components/Features/Features.css
+++ b/components/Features/Features.css
@@ -26,18 +26,7 @@
   color: var(--secondary-text-color);
 }
 
-.container {
-  /* Flex container */
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 10px;
-  margin-top: 50px;
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.container .stages .stage {
+.stages .stage {
   /* Stage styles */
   text-align: center;
   margin-bottom: 10px;
@@ -49,8 +38,7 @@
   color: var(--secondary-text-color);
   border-radius: 5px;
 }
-
-.container .stages .stage h3 {
+.stages .stage h3 {
   /* Stage title */
   font-size: 28px;
   font-weight: bold;

--- a/components/Features/Features.tsx
+++ b/components/Features/Features.tsx
@@ -61,7 +61,7 @@ function Features (): JSX.Element {
 				<p className="des">Lorem ipsum dolor sit amet consectetur adipisicing elit.
 					Explicabo at a dolor voluptatum.</p>
 			</div>
-			<div className="container">
+			<div className="flex align-middle justify-end gap-2.5 mt-12 mx-0">
 				<div className="stages">
 					{stages.map(stage => (
 						<div key={stage.id} className={`stage ${stage.id === currentStage

--- a/components/Hero/Hero.css
+++ b/components/Hero/Hero.css
@@ -14,16 +14,6 @@
     margin-top: 25px;
 }
 
-.hero-mist-1 {
-    position: absolute;
-    height: 400px;
-    width: 400px;
-    left: 150px;
-    top: 300px;
-    z-index: -1;
-    overflow: hidden;
-}
-
 /* Main title styles */
 .title {
     margin: auto;

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -47,7 +47,6 @@ const Hero = (props: {
 
 	return (
 		<div className="hero">
-			<div className="blue-neon-mist hero-mist-1"></div>
 			<div className="hero-container">
 				{/* Title with decorative SVG elements */}
 				<h1 className="title title-sm">


### PR DESCRIPTION
## What

Fix issue causing mobile width to overflow the device margins, causing a large overflow section on the right hand side.

## Why

This was not the desired design on the mobile site.

## How

Removed some unused elements and adjusted so use of the reserved class container.

## Screenshots / GIFs (if applicable)

![image](https://github.com/StudyCrew/StudyCrew/assets/74150974/a7021df9-3adc-453b-9ac5-91f46d3f917d)

## Checklist

- [x] I have tested these changes locally
- [x] I have ensured my code follows the project's coding style
- [x] I have updated the documentation accordingly
- [x] My changes do not introduce any new warnings or errors
- [x] All tests pass successfully
- [x] I have added/updated unit tests (if necessary)

## Additional Notes

It looks like most of the work thus far for the home page has been working around this issue, and in fixing this, most of the rest of the page is now broken. To resolve this I am going to raise a number of issues. @JacobHeldt you should be aware of the impact this has had.