### PR TITLE
Merge 121-mobile-button-width into develop

### DIFF
--- a/components/Button/Button.css
+++ b/components/Button/Button.css
@@ -52,10 +52,3 @@
     padding: 8px 18px;
     font-size: 14px;
 }
-
-/* Make width of buttons higher on mobile */
-@media screen and (max-width: 768px) { 
-    .button-big, .button-big-outline {
-        width: 75vw;
-    }
-}


### PR DESCRIPTION
## What

Resolved issue with mobile button in the hero having an excessive width.

## Why

It's makes the button overflow its parent container.

## How

By removing some `Button.css` styling that was causing the excessive width.

## Screenshots / GIFs (if applicable)

Desktop still looks okay:
![image](https://github.com/StudyCrew/StudyCrew/assets/74150974/f27ab4d5-dca5-49d6-bc64-88c3e727253f)

Mobile now looks good:
![image](https://github.com/StudyCrew/StudyCrew/assets/74150974/fa3b76e9-e8ef-4a3e-a291-43e5c3b81566)

## Checklist

- [x] I have tested these changes locally
- [x] I have ensured my code follows the project's coding style
- [x] I have updated the documentation accordingly
- [x] My changes do not introduce any new warnings or errors
- [x] All tests pass successfully
- [x] I have added/updated unit tests (if necessary)