### PR TITLE
Merge 183-middleware-clerkjs-sentry-monitoring-blocked-by-auth into develop

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -5,7 +5,7 @@ import { authMiddleware } from '@clerk/nextjs'
 
 export default authMiddleware({
 	// An array of public routes that don't require authentication.
-	publicRoutes: ['/api/webhook/clerk'],
+	publicRoutes: ['/api/webhook/clerk', '/assets/(.*)', '/monitoring'],
 
 	// An array of routes to be ignored by the authentication middleware.
 	ignoredRoutes: ['/api/webhook/clerk', '/'],


### PR DESCRIPTION
## What

Added public routes to auth middleware for Sentry monitoring calls.

## Why

This was blocking calls to the Sentry monitoring functionality.

## How

Added middlware `publicRoutes` for `/monitoring`

## Related Issues

#177 

## Checklist

- [x] I have tested these changes locally
- [x] I have ensured my code follows the project's coding style
- [x] I have updated the documentation accordingly
- [x] My changes do not introduce any new warnings or errors
- [x] All tests pass successfully
- [x] I have added/updated unit tests (if necessary)

## Additional Notes

I also added the exception for all assets whilst I was here and this was also causing console errors.