### PR TITLE
Feature: Add CI GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+---
+name: CI
+
+env:
+  HUSKY: 0
+
+on:
+  push:
+    branches: ['main', 'develop']
+  pull_request:
+    branches: ['main', 'develop']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x, 20.x]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm i
+
+      - name: Check Format
+        run: pnpm format:check
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2


### PR DESCRIPTION
## What

Adds a new GitHub Action named `CI` that runs `format:check`, `lint` and `build` on each PR and push to `develop` and `main`.

The `test` script is omitted as it is currently failing on latest `develop` and I suspect tests haven't been updated in some time.

Closes #264 

## Why

This is useful to automatically check PRs for linter & formatting issues, failing tests, and failing builds.

## Checklist

- [x] I have tested these changes locally
- [x] I have ensured my code follows the project's coding style
- [x] I have updated the documentation accordingly
- [x] My changes do not introduce any new warnings or errors
- [x] All tests pass successfully
- [x] I have added/updated unit tests (if necessary)

## NOTE

**The action needs to be added as a requirement for PR merges after merging this PR.**