### PR TITLE
Change Arrow1.svg to the public/assets issue (#36)

### DIFF
--- a/public/assets/Arrow1.svg
+++ b/public/assets/Arrow1.svg
@@ -1,0 +1,9 @@
+<svg width="2628" height="376" viewBox="0 0 2628 376" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 0L1297.12 266.157C1305.53 267.883 1309.74 268.747 1314 268.747C1318.26 268.747 1322.47 267.883 1330.88 266.157L2628 0V105.564L1330.96 372.509C1322.51 374.248 1318.28 375.118 1314 375.117C1309.72 375.115 1305.49 374.243 1297.04 372.498L0 104.642V0Z" fill="url(#paint0_linear_131_472)"/>
+<defs>
+<linearGradient id="paint0_linear_131_472" x1="2628" y1="0.000457183" x2="-13.2544" y2="169.679" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4D8EFB"/>
+<stop offset="1" stop-color="#3833A6"/>
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
Changing the svg to the file corresponding to assets of images

## What

<!-- Briefly describe the changes introduced by this pull request -->
changing the file svg in `components/missions` in the `public/assets`


## Why

Assets should not be in the same folder as the component, this should be with the rest of the assets

## How

changing the file to the corresponding directory 


## Related Issues

<!-- Mention any related issues or links to discussions -->

## Screenshots / GIFs (if applicable)

![image](https://github.com/StudyCrew/StudyCrew/assets/107327344/9608ec07-6106-411e-ac94-72df54b1a308)

## Checklist

- [ ] I have tested these changes locally
- [ ] I have ensured my code follows the project's coding style
- [ ] I have updated the documentation accordingly
- [ ] My changes do not introduce any new warnings or errors
- [ ] All tests pass successfully
- [ ] I have added/updated unit tests (if necessary)

## Additional Notes

<!-- Any additional information or notes for the reviewers -->

