### PR TITLE
style(component)!: update Project margin and font size to match proposed mobile design; use tailwind classes

### DIFF
--- a/src/components/Project/index.tsx
+++ b/src/components/Project/index.tsx
@@ -7,40 +7,36 @@ import './style.css'
 
 const Project = (): JSX.Element => {
   return (
-    <div className="project-main-div">
-      <div className="project-left-column">
-        <div className="project-text">
-          <h3 className="project-mission-header text-zircon-50">OUR PROJECT</h3>
-          <h2 className="project-mission-title text-zircon-50 slogan">
-            Transforming Education Together.
-          </h2>
-          <p className="project-mission-text text-zircon-50">
-            Dedicated to transforming the educational landscape, our platform
-            prioritizes accessibility, collaboration, and engagement. We are
-            committed to ensure quality education is in everyone’s reach.
-            Together, we’re constructing a platform that emphasizes
-            collaborative learning. Embracing the spirit of collective knowledge
-            and democratizing learning, our project is open-source, ensuring
-            continuous innovation and community-driven enhancements.
-          </p>
-        </div>
+    <div className="flex bg-gradient-to-r from-primary-500 to-gradient-500">
+      <div className="flex flex-col gap-2 px-11 md:px-36 py-14">
+        <h2 className="text-lg font-normal text-zircon-50">Our Project</h2>
+        <h3 className="text-5xl font-semibold m-0 text-zircon-50">Transforming Education Together.</h3>
+        <p className="text-zircon-50">
+          Dedicated to transforming the educational landscape, our platform
+          prioritizes accessibility, collaboration, and engagement. We are
+          committed to ensure quality education is in everyone’s reach.
+          Together, we’re constructing a platform that emphasizes collaborative
+          learning. Embracing the spirit of collective knowledge and
+          democratizing learning, our project is open-source, ensuring
+          continuous innovation and community-driven enhancements.
+        </p>
       </div>
 
-      <div className="project-right-column">
+      <div className="hidden md:flex md:flex-auto md:relative md:items-center md:justify-center">
         <Image
           src={PROJECT_IMAGE_JPG}
-          className="project-image"
+          className="w-full h-full object-cover"
           alt="Project representation"
         />
-        <div className="project-image-subtitle">
-          <div>
+        <blockquote className="absolute bottom-0 left-0 p-12 bg-white/65 backdrop-blur-lg">
+          <p>
             “Every student deserves a dynamic and engaging educational
             experience. Let&apos;s build it together.”
-          </div>
-          <div className="project-subtitle-name">
+          </p>
+          <cite className="text-lg mt-8 text-secondary-text-700">
             - Jacob, Founder of StudyCrew
-          </div>
-        </div>
+          </cite>
+        </blockquote>
       </div>
     </div>
   )

--- a/src/components/Project/index.tsx
+++ b/src/components/Project/index.tsx
@@ -28,12 +28,12 @@ const Project = (): JSX.Element => {
           className="w-full h-full object-cover"
           alt="Project representation"
         />
-        <blockquote className="absolute bottom-0 left-0 p-12 bg-white/65 backdrop-blur-lg">
+        <blockquote className="absolute bottom-0 left-0 flex flex-col gap-2 p-12 bg-white/65 backdrop-blur-lg">
           <p>
             “Every student deserves a dynamic and engaging educational
             experience. Let&apos;s build it together.”
           </p>
-          <cite className="text-lg mt-8 text-secondary-text-700">
+          <cite className="text-lg text-secondary-text-700">
             - Jacob, Founder of StudyCrew
           </cite>
         </blockquote>


### PR DESCRIPTION
## What
- fix mobile layout margin and font sizes
- refactor styling using tailwind classes
 
## Why
- the subheader for project currently has too large of a margin to the top of the section
- the font size is too small

## How
- use tailwind classes to fix margin, font sizes
- `gap` used in place of margins on flex items
- replace quote `div`s with semantic html: `blockquote`, `p` and `cite` 
- fix heading ranks (text/left column) to comply with WCAG criteria (descending order)
- remove extra `div` container in text/left column
- use `md:` breakpoint target for non-mobile style

## Related Issues
- #124 
- #244

## Screenshots / GIFs (if applicable)
### mobile
![image](https://github.com/StudyCrew/StudyCrew/assets/54294370/7f8b7416-037e-4525-9cba-24f1e8376c28)

### desktop
![image](https://github.com/StudyCrew/StudyCrew/assets/54294370/5b31e637-40a6-4bf1-8a97-f3a1bf5ed8df)

## Checklist
- [x] I have tested these changes locally
- [x] I have ensured my code follows the project's coding style
- [ ] I have updated the documentation accordingly
- [x] My changes do not introduce any new warnings or errors
- [x] All tests pass successfully
- [ ] I have added/updated unit tests (if necessary)

## Additional Notes
- BREAKING CHANGE: media queries were pointing to 500, 720 and 1120px, which do not currently match any tailwind screen breakpoints. said media queries seem to be used in the other components, so the project component breakpoint isn't in sync with the rest of the page. this problem should go away once all components are converted to tailwind's breakpoints. alternatively, the breakpoints can be adjusted in the tailwind config to match the existing media queries.
- `h3` element seems to be picking up additional margin styling from a selector outside the component (global?). used the `m-0` tailwind class to remedy this until said selector is found
- no tailwind config pointing to the **Rubik** font-family. heading fonts in these commits do not match the design