### PR TITLE
fix: resolve tailwind font configuration conflicts

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,10 +1,13 @@
 @import url('https://fonts.googleapis.com/css2?family=Rubik:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,500&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,200;0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,200;1,9..40,300;1,9..40,400;1,9..40,600&family=Rubik:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,500&display=swap');
 
+@tailwind base;
 @tailwind components;
 @tailwind utilities;
-@layer tailwind {
-  @tailwind base;
+@layer base {
+  h1, h2, h3, h4, h5, h6, button {
+    @apply font-serif;
+  }
 }
 
 * {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,10 +1,20 @@
-@import url('https://fonts.googleapis.com/css2?family=Rubik:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,500&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,200;0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,200;1,9..40,300;1,9..40,400;1,9..40,600&family=Rubik:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,500&display=swap');
+/* @import url('https://fonts.googleapis.com/css2?family=Rubik:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,500&display=swap'); */
+/* @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,200;0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,200;1,9..40,300;1,9..40,400;1,9..40,600&family=Rubik:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,500&display=swap'); */
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 @layer base {
+  @font-face {
+    font-family: 'Rubik';
+    src: url('/fonts/rubik/Rubik-VariableFont_wght.ttf');
+  }
+
+  @font-face {
+    font-family: 'DM Sans';
+    src: url('/fonts/dmsans/DMSans-VariableFont_opsz,wght.ttf');
+  }
+
   h1,
   h2,
   h3,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,9 +23,9 @@
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+  /* font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+    sans-serif; */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -47,7 +47,7 @@ h4,
 h5,
 h6,
 button {
-  font-family: var(--heading-font);
+  /* font-family: var(--heading-font); */
   color: var(--primary-text-color);
 }
 
@@ -56,11 +56,11 @@ p,
 span,
 input,
 textarea {
-  font-family: var(--text-font);
+  /* font-family: var(--text-font); */
 }
 
 h3 {
-  font-family: var(--text-font);
+  /* font-family: var(--text-font); */
   font-weight: 300;
   font-size: 22px;
 }
@@ -68,12 +68,12 @@ h3 {
 h2 {
   font-weight: 500;
   font-size: 50px;
-  font-family: var(--heading-font);
+  /* font-family: var(--heading-font); */
 }
 
 h2 span {
   color: var(--primary-color);
-  font-family: var(--heading-font);
+  /* font-family: var(--heading-font); */
 }
 
 p {
@@ -82,7 +82,7 @@ p {
 }
 
 .heading-font {
-  font-family: var(--heading-font);
+  /* font-family: var(--heading-font); */
 }
 
 .text-gradient {
@@ -96,7 +96,7 @@ p {
 }
 
 .text-font {
-  font-family: var(--text-font);
+  /* font-family: var(--text-font); */
 }
 
 .primary-text-color {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,7 +5,13 @@
 @tailwind components;
 @tailwind utilities;
 @layer base {
-  h1, h2, h3, h4, h5, h6, button {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  button {
     @apply font-serif;
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,3 @@
-/* @import url('https://fonts.googleapis.com/css2?family=Rubik:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,500&display=swap'); */
-/* @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,200;0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,200;1,9..40,300;1,9..40,400;1,9..40,600&family=Rubik:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,500&display=swap'); */
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -36,15 +33,10 @@
   --light-background-color: #f2f7ff;
   --primary-text-color: #0c1b33;
   --secondary-text-color: #434c59;
-  --heading-font: 'Rubik', sans-serif;
-  --text-font: 'DM Sans', sans-serif;
 }
 
 body {
   margin: 0;
-  /* font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif; */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -66,20 +58,10 @@ h4,
 h5,
 h6,
 button {
-  /* font-family: var(--heading-font); */
   color: var(--primary-text-color);
 }
 
-body,
-p,
-span,
-input,
-textarea {
-  /* font-family: var(--text-font); */
-}
-
 h3 {
-  /* font-family: var(--text-font); */
   font-weight: 300;
   font-size: 22px;
 }
@@ -87,21 +69,15 @@ h3 {
 h2 {
   font-weight: 500;
   font-size: 50px;
-  /* font-family: var(--heading-font); */
 }
 
 h2 span {
   color: var(--primary-color);
-  /* font-family: var(--heading-font); */
 }
 
 p {
   font-size: 19px;
   letter-spacing: 0.1px;
-}
-
-.heading-font {
-  /* font-family: var(--heading-font); */
 }
 
 .text-gradient {
@@ -112,10 +88,6 @@ p {
   );
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
-}
-
-.text-font {
-  /* font-family: var(--text-font); */
 }
 
 .primary-text-color {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,6 +10,10 @@ const tailwindConfig = {
   content: ['./src/**/*.{ts,tsx}'],
   plugins: [tailwindCSSAnimate],
   theme: {
+    fontFamily: {
+      'sans': ['"DM Sans"', 'ui-sans-serif'],
+      'serif': ['Rubik','ui-serif']
+    },
     container: {
       center: true,
       padding: '2rem',


### PR DESCRIPTION
## What
- add tailwind config fonts to override `font-sans` and `font-serif` classes to **DM Sans** and **Rubik**, respectively
- comment out `font-family` properties in `globals.css`
- fix `@tailwind base` directive; apply `font-serif`/**Rubik** font to headings and buttons via preflight extension
- ADDED: host fonts locally instead of importing from google fonts

## Why
Allow tailwind to handle typography-related styling instead of custom/global CSS

## How
- I followed Tailwind docs and went with instructions around:
  - overriding tailwind config's `font-sans` and `font-serif` utility classes: https://tailwindcss.com/docs/font-family
  - preflight extensions to override the tailwind base directive: https://tailwindcss.com/docs/preflight
- commented out `font-family` properties in the global CSS that would have applied DM Sans/Rubik fonts
  - i also commented out the `font-family` property in the `body` selector
  - i ignored the `font-family` property for the `code` selector (I didn't see any mono types defined in the [design system](https://www.figma.com/file/Y7kX0ZhQSXqldqx1GLdVaT/StudyCrew-Prototypes?type=design&node-id=1237-278&mode=design&t=BRXhqTiJC6nkAoz7-0); decided on leaving it alone)
- replace font `@import` with `@font-face` rule, applied as preflight extension 
## Related Issues
- fixes #313
- also fixes #309 (I needed a way to confirm that Rubik was being applied to headings/buttons) 

## Screenshots / GIFs (if applicable)
![image](https://github.com/StudyCrew/StudyCrew/assets/54294370/b41e269b-d217-4148-9028-098333a97cb8)


## Checklist

- [x] I have tested these changes locally
- [x] I have ensured my code follows the project's coding style
- [ ] I have updated the documentation accordingly
- [x] My changes do not introduce any new warnings or errors
- [x] All tests pass successfully
- [ ] I have added/updated unit tests (if necessary)

## Additional Notes
- ~~I am a little uneasy around pushing up commented-out code, but this also seems like least disruptive way to tackle styling until the rest of the components are converted over to using tailwind utility classes~~
- this seems like a good point of reference for issues relating to tailwind conversions and preserving component/utility classes from the original CSS: https://tailwindcss.com/docs/functions-and-directives#layer