### PR TITLE
571 frontend make group cards width responsive

### DIFF
--- a/src/app/(core)/groups/(overview)/page.tsx
+++ b/src/app/(core)/groups/(overview)/page.tsx
@@ -136,7 +136,7 @@ export default function GroupsPage(): JSX.Element {
           <h2 className="font-rubik font-bold text-2xl sm:text-3xl">
             My Groups
           </h2>
-          <Button text="+ Create Group" className="w-[130px] h-9"></Button>
+          <Button text="+ Create Group"></Button>
         </div>
         <MyGroups />
       </section>
@@ -164,7 +164,7 @@ export default function GroupsPage(): JSX.Element {
             {SUBJECTS.map((subject: any) => (
               <li
                 key={subject.id}
-                className={`rounded-full p-2 border border-solid border-primary-blue cursor-pointer flex-shrink-0 ${
+                className={`rounded-full py-2 px-2 border border-solid border-primary-blue cursor-pointer flex-shrink-0 ${
                   selectedSubject === subject.name
                     ? 'bg-primary-blue text-white'
                     : 'bg-white'

--- a/src/app/(core)/layout.tsx
+++ b/src/app/(core)/layout.tsx
@@ -12,7 +12,7 @@ export default function ApplicationLayout({
   return (
     <div className={'flex bg-gray-100 w-screen'}>
       <NavbarHelper />
-      <div className={'flex-1 px-4 md:px-6 lg:px-10'}>
+      <div className={'flex-1 px-4 md:px-12 lg:px-16'}>
         <PageHeader />
         {children}
       </div>

--- a/src/components/widgets/groupcard/GroupCard.tsx
+++ b/src/components/widgets/groupcard/GroupCard.tsx
@@ -28,7 +28,7 @@ const GroupCard: React.FC<GroupCardProps> = ({
   return (
     <div
       key={key}
-      className="groupCard w-[360px] h-[280px] flex flex-col rounded-2xl bg-white"
+      className="groupCard w-full h-[280px] flex flex-col rounded-2xl bg-white"
     >
       <div
         className="banner w-full h-[128px] relative rounded-t-2xl"


### PR DESCRIPTION
Make sure the group cards take up their appropriate width in flex containers and slightly increase the overall horizontal padding to page borders.