### PR TITLE
Remove opinionated settings in .settings configuration

### DIFF
--- a/.vscode/.settings
+++ b/.vscode/.settings
@@ -1,9 +1,4 @@
 {
   "editor.defaultFormatter": "rvest.vs-code-prettier-eslint",
-  "editor.formatOnPaste": false,
-  "editor.formatOnType": false,
-  "editor.formatOnSave": true,
-  "editor.formatOnSaveMode": "file",
-  "files.autoSave": "onFocusChange",
   "vs-code-prettier-eslint.prettierLast": "false"
 }


### PR DESCRIPTION
## What

<!-- Briefly describe the changes introduced by this pull request -->

Removes unnecessary settings from the `.vscode/.settings` file

## Why

<!-- Why were these changes neccesary? -->

Those settings does not improve the code quality nor the developer experience.

## How

<!-- Describe in detail the changes and improvements made by this PR -->

Removed the settings `editor.formatOnPaste`, `editor.formatOnType`, `editor.formatOnSave`, `editor.formatOnSaveMode` and `files.autoSave` from .vscode/.settings.

## Related Issues

closes #646 

## Screenshots / GIFs (if applicable)

<!-- If applicable, add screenshots or GIFs showcasing the changes -->

Not applicable

## Checklist

- [x] I have tested these changes locally
- [x] I have ensured my code follows the project's coding style
- [x] I have updated the documentation accordingly
- [x] My changes do not introduce any new warnings or errors
- [x] All tests pass successfully
- [x] I have added/updated unit tests (if necessary)

## Additional Notes

<!-- Any additional information or notes for the reviewers -->